### PR TITLE
[Feature] Quick Settings Tile, Create QR codes for scanned items

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -27,7 +27,7 @@
         android:label="@string/app_name"
         android:roundIcon="@mipmap/ic_launcher_round"
         android:supportsRtl="true"
-        android:theme="@style/Theme.QRScanner"
+        android:theme="@style/DarkTheme"
         tools:targetApi="33">
         <activity
             android:name=".ui.SettingsActivity"
@@ -42,14 +42,23 @@
             android:exported="true">
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />
-
                 <category android:name="android.intent.category.LAUNCHER" />
             </intent-filter>
-
             <meta-data
                 android:name="android.app.lib_name"
                 android:value="" />
         </activity>
+
+        <service
+            android:name=".utils.ScannerTileService"
+            android:exported="true"
+            android:icon="@drawable/tile_scanner_24"
+            android:label="@string/app_name"
+            android:permission="android.permission.BIND_QUICK_SETTINGS_TILE">
+            <intent-filter>
+                <action android:name="android.service.quicksettings.action.QS_TILE" />
+            </intent-filter>
+        </service>
     </application>
 
 </manifest>

--- a/app/src/main/java/com/yatik/qrscanner/adapters/history/HistoryAdapter.kt
+++ b/app/src/main/java/com/yatik/qrscanner/adapters/history/HistoryAdapter.kt
@@ -58,12 +58,13 @@ class HistoryAdapter :
 
         date.text = "· $dateTime"
 
-        if (barcodeData != null) {
-            tvTitle.text = barcodeData.title?.let {
-                if (it.isEmpty()) barcodeData.decryptedText
-                else if (it.length < 51) it
-                else "${it.substring(0, 47)}..."
-            }
+        tvTitle.text = barcodeData?.title?.let {
+            if (it.isEmpty()) {
+                val text = barcodeData.decryptedText.toString()
+                if (text.length <= 50) text
+                else "${text.substring(0, 47)}..."
+            } else if (it.length <= 50) it
+            else "${it.substring(0, 47)}..."
         }
         when (format) {
             Barcode.FORMAT_QR_CODE -> {

--- a/app/src/main/java/com/yatik/qrscanner/ui/fragments/details/DetailsFragment.kt
+++ b/app/src/main/java/com/yatik/qrscanner/ui/fragments/details/DetailsFragment.kt
@@ -313,7 +313,6 @@ class DetailsFragment : Fragment() {
         _binding = null
     }
 
-    lateinit var barcodeData: BarcodeData
     private fun barcodeDataToGeneratorData(barcodeData: BarcodeData): GeneratorData =
         GeneratorData(
             type = barcodeData.type,

--- a/app/src/main/java/com/yatik/qrscanner/utils/PermissionHelper.kt
+++ b/app/src/main/java/com/yatik/qrscanner/utils/PermissionHelper.kt
@@ -1,0 +1,50 @@
+package com.yatik.qrscanner.utils
+
+import android.Manifest
+import android.content.Context
+import android.content.pm.PackageManager
+import androidx.activity.result.ActivityResultLauncher
+import androidx.activity.result.contract.ActivityResultContracts
+import androidx.core.content.ContextCompat
+import androidx.fragment.app.Fragment
+import com.yatik.qrscanner.R
+
+class PermissionHelper {
+
+    fun isCameraPermissionGranted(context: Context): Boolean = ContextCompat.checkSelfPermission(
+        context,
+        Manifest.permission.CAMERA
+    ) == PackageManager.PERMISSION_GRANTED
+
+    /**
+     * Checks if the camera permission is already granted,
+     * and if not, it launches a permission request dialog using the [ActivityResultContracts.RequestPermission] API.
+     * It also handles the result of the permission request and shows a [noPermissionDialog] if the permission is denied.
+     *
+     * @param context Context object of the registering fragment.
+     * @param fragment The fragment object that is registering for the permission request result.
+     *
+     * @see [Manifest.permission.CAMERA]
+     */
+    fun requestCameraPermission(context: Context, fragment: Fragment) {
+
+        val requestPermissionLauncher: ActivityResultLauncher<String>
+
+        if (!isCameraPermissionGranted(context)) {
+            requestPermissionLauncher = fragment.registerForActivityResult(
+                ActivityResultContracts.RequestPermission()
+            ) {
+                if (!it) {
+                    noPermissionDialog(
+                        context,
+                        context.getString(R.string.permissionDeniedMessageCam)
+                    )
+                }
+            }
+            requestPermissionLauncher.launch(
+                Manifest.permission.CAMERA
+            )
+        }
+    }
+
+}

--- a/app/src/main/java/com/yatik/qrscanner/utils/ScannerTileService.kt
+++ b/app/src/main/java/com/yatik/qrscanner/utils/ScannerTileService.kt
@@ -1,0 +1,24 @@
+package com.yatik.qrscanner.utils
+
+import android.content.Intent
+import android.net.Uri
+import android.os.Build
+import android.service.quicksettings.TileService
+import androidx.annotation.RequiresApi
+
+@RequiresApi(Build.VERSION_CODES.N)
+class ScannerTileService : TileService() {
+
+    override fun onClick() {
+        super.onClick()
+        val launchIntent = packageManager.getLaunchIntentForPackage(packageName)
+        if (launchIntent != null) {
+            startActivityAndCollapse(launchIntent)
+        } else {
+            val playStoreIntent = Intent(Intent.ACTION_VIEW)
+            playStoreIntent.data = Uri.parse("market://details?id=$packageName")
+            startActivityAndCollapse(playStoreIntent)
+        }
+    }
+
+}

--- a/app/src/main/res/drawable/baseline_qr_code_scanner_24.xml
+++ b/app/src/main/res/drawable/baseline_qr_code_scanner_24.xml
@@ -1,0 +1,10 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="32dp"
+    android:height="32dp"
+    android:tint="?colorOnPrimary"
+    android:viewportWidth="24"
+    android:viewportHeight="24">
+    <path
+        android:fillColor="@android:color/white"
+        android:pathData="M9.5,6.5v3h-3v-3H9.5M11,5H5v6h6V5L11,5zM9.5,14.5v3h-3v-3H9.5M11,13H5v6h6V13L11,13zM17.5,6.5v3h-3v-3H17.5M19,5h-6v6h6V5L19,5zM13,13h1.5v1.5H13V13zM14.5,14.5H16V16h-1.5V14.5zM16,13h1.5v1.5H16V13zM13,16h1.5v1.5H13V16zM14.5,17.5H16V19h-1.5V17.5zM16,16h1.5v1.5H16V16zM17.5,14.5H19V16h-1.5V14.5zM17.5,17.5H19V19h-1.5V17.5zM22,7h-2V4h-3V2h5V7zM22,22v-5h-2v3h-3v2H22zM2,22h5v-2H4v-3H2V22zM2,2v5h2V4h3V2H2z" />
+</vector>

--- a/app/src/main/res/drawable/tile_scanner_24.xml
+++ b/app/src/main/res/drawable/tile_scanner_24.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="utf-8"?>
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24">
+    <path
+        android:fillColor="#FFFFFFFF"
+        android:pathData="M9 5.4V9H5.4V5.4H9Zm1.8-1.8H3.6v7.2h7.2V3.6ZM9 15v3.6H5.4V15H9Zm1.8-1.8H3.6v7.2h7.2v-7.2Zm7.8-7.8V9H15V5.4h3.6Zm1.8-1.8h-7.2v7.2h7.2V3.6Zm-7.2 9.6H15V15h-1.8v-1.8ZM15 15h1.8v1.8H15V15Zm1.8-1.8h1.8V15h-1.8v-1.8Zm-3.6 3.6H15v1.8h-1.8v-1.8Zm1.8 1.8h1.8v1.8H15v-1.8Zm1.8-1.8h1.8v1.8h-1.8v-1.8Zm1.8-1.8h1.8v1.8h-1.8V15Zm0 3.6h1.8v1.8h-1.8v-1.8ZM24 6h-2.4V2.4H18V0h6v6Zm0 18v-6h-2.4v3.6H18V24h6ZM0 24h6v-2.4H2.4V18H0v6ZM0 0v6h2.4V2.4H6V0H0Z" />
+</vector>

--- a/app/src/main/res/layout/fragment_details.xml
+++ b/app/src/main/res/layout/fragment_details.xml
@@ -117,10 +117,9 @@
                     app:iconSize="28dp"
                     app:layout_constraintBottom_toBottomOf="parent"
                     app:layout_constraintEnd_toStartOf="@+id/share_button"
-                    app:layout_constraintHorizontal_bias="0.08"
+                    app:layout_constraintHorizontal_bias="0.5"
                     app:layout_constraintStart_toStartOf="parent"
                     app:layout_constraintTop_toTopOf="parent"
-                    app:layout_constraintVertical_bias="0.0"
                     tools:ignore="HardcodedText" />
 
                 <com.google.android.material.button.MaterialButton
@@ -134,25 +133,25 @@
                     app:iconGravity="top"
                     app:iconSize="28dp"
                     app:layout_constraintBottom_toBottomOf="parent"
-                    app:layout_constraintEnd_toEndOf="parent"
-                    app:layout_constraintStart_toStartOf="parent"
+                    app:layout_constraintEnd_toStartOf="@+id/details_to_qr_button"
+                    app:layout_constraintHorizontal_bias="0.5"
+                    app:layout_constraintStart_toEndOf="@+id/copy_button"
                     app:layout_constraintTop_toTopOf="parent"
                     tools:ignore="HardcodedText" />
 
                 <com.google.android.material.button.MaterialButton
-                    android:id="@+id/wifi_button"
+                    android:id="@+id/details_to_qr_button"
                     android:layout_width="wrap_content"
                     android:layout_height="wrap_content"
                     android:backgroundTint="?colorPrimaryVariant"
-                    android:contentDescription="open wifi settings"
-                    android:text="@string/Wifi"
-                    android:visibility="gone"
-                    app:icon="@drawable/outline_wifi_32"
+                    android:contentDescription="@string/share"
+                    android:text="@string/create"
+                    app:icon="@drawable/baseline_qr_code_scanner_24"
                     app:iconGravity="top"
                     app:iconSize="28dp"
                     app:layout_constraintBottom_toBottomOf="parent"
-                    app:layout_constraintEnd_toEndOf="parent"
-                    app:layout_constraintHorizontal_bias="0.822"
+                    app:layout_constraintEnd_toStartOf="@+id/launch_button"
+                    app:layout_constraintHorizontal_bias="0.5"
                     app:layout_constraintStart_toEndOf="@+id/share_button"
                     app:layout_constraintTop_toTopOf="parent"
                     tools:ignore="HardcodedText" />
@@ -161,7 +160,6 @@
                     android:id="@+id/launch_button"
                     android:layout_width="wrap_content"
                     android:layout_height="wrap_content"
-                    android:layout_marginEnd="16dp"
                     android:backgroundTint="?colorPrimaryVariant"
                     android:contentDescription="launch"
                     android:text="@string/launch"
@@ -170,6 +168,8 @@
                     app:iconSize="28dp"
                     app:layout_constraintBottom_toBottomOf="parent"
                     app:layout_constraintEnd_toEndOf="parent"
+                    app:layout_constraintHorizontal_bias="0.5"
+                    app:layout_constraintStart_toEndOf="@+id/details_to_qr_button"
                     app:layout_constraintTop_toTopOf="parent"
                     tools:ignore="HardcodedText" />
             </androidx.constraintlayout.widget.ConstraintLayout>
@@ -200,7 +200,7 @@
                     android:layout_width="match_parent"
                     android:layout_height="wrap_content"
                     android:layout_marginStart="95dp"
-                    android:layout_marginTop="8dp"
+                    android:layout_marginTop="10dp"
                     android:layout_marginEnd="8dp"
                     android:text="TextView"
                     android:textIsSelectable="true"
@@ -226,8 +226,8 @@
                     android:layout_width="match_parent"
                     android:layout_height="wrap_content"
                     android:layout_marginStart="95dp"
-                    android:layout_marginTop="4dp"
-                    android:layout_marginBottom="8dp"
+                    android:layout_marginTop="2dp"
+                    android:layout_marginBottom="10dp"
                     android:text="LinkView"
                     android:textColor="#037EFF"
                     android:textSize="17sp"
@@ -249,7 +249,7 @@
                 app:layout_constraintBottom_toBottomOf="parent"
                 app:layout_constraintEnd_toEndOf="parent"
                 app:layout_constraintStart_toStartOf="parent"
-                app:layout_constraintTop_toBottomOf="@id/constraintLayout" >
+                app:layout_constraintTop_toBottomOf="@id/constraintLayout">
 
                 <include layout="@layout/shimmer_preview_layout" />
 

--- a/app/src/main/res/layout/fragment_qr_code_generator.xml
+++ b/app/src/main/res/layout/fragment_qr_code_generator.xml
@@ -3,6 +3,7 @@
 <androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
     xmlns:tools="http://schemas.android.com/tools"
+    android:id="@+id/qr_code_generator_main"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
     android:background="?colorPrimary"

--- a/app/src/main/res/layout/recyclerview_item.xml
+++ b/app/src/main/res/layout/recyclerview_item.xml
@@ -10,8 +10,8 @@
 
     <ImageView
         android:id="@+id/history_icon"
-        android:layout_width="0dp"
-        android:layout_height="0dp"
+        android:layout_width="60dp"
+        android:layout_height="60dp"
         android:padding="12dp"
         app:layout_constraintBottom_toTopOf="@id/line1"
         app:layout_constraintEnd_toStartOf="@id/guideline_start"
@@ -54,8 +54,8 @@
 
     <com.google.android.material.button.MaterialButton
         android:id="@+id/delete_button"
-        android:layout_width="0dp"
-        android:layout_height="0dp"
+        android:layout_width="60dp"
+        android:layout_height="60dp"
         android:backgroundTint="?colorPrimary"
         android:contentDescription="delete item"
         app:icon="@drawable/outline_delete_24"

--- a/app/src/main/res/navigation/main_nav_graph.xml
+++ b/app/src/main/res/navigation/main_nav_graph.xml
@@ -65,5 +65,10 @@
         <argument
             android:name="barcodeData"
             app:argType="com.yatik.qrscanner.models.BarcodeData" />
+        <action
+            android:id="@+id/action_detailsFragment_to_generatorFragment"
+            app:destination="@id/generatorFragment"
+            app:enterAnim="@anim/slide_in_right"
+            app:popEnterAnim="@anim/slide_in_left" />
     </fragment>
 </navigation>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -59,6 +59,8 @@
     <string name="share">Share</string>
     <string name="launch">Launch</string>
     <string name="fetching">fetching...</string>
+    <string name="create">Create</string>
+    <string name="create_qr_notif_message">Click here to create QR Code</string>
 
 
     <string-array name="theme_types">

--- a/app/src/main/res/xml/preferences.xml
+++ b/app/src/main/res/xml/preferences.xml
@@ -69,7 +69,7 @@
 
         <Preference
             android:key="version_preference"
-            android:summary="2.2.0"
+            android:summary="2.2.1"
             android:title="App version" />
 
     </PreferenceCategory>

--- a/app/src/test/java/com/yatik/qrscanner/FakePagingSource.kt
+++ b/app/src/test/java/com/yatik/qrscanner/FakePagingSource.kt
@@ -4,7 +4,8 @@ import androidx.paging.PagingSource
 import androidx.paging.PagingState
 import com.yatik.qrscanner.models.BarcodeData
 
-class FakePagingSource(private val barcodeDataList: List<BarcodeData>) : PagingSource<Int, BarcodeData>() {
+class FakePagingSource(private val barcodeDataList: List<BarcodeData>) :
+    PagingSource<Int, BarcodeData>() {
 
     override fun getRefreshKey(state: PagingState<Int, BarcodeData>): Int? {
         return null

--- a/app/src/test/java/com/yatik/qrscanner/repository/details/DefaultDetailsRepositoryTest.kt
+++ b/app/src/test/java/com/yatik/qrscanner/repository/details/DefaultDetailsRepositoryTest.kt
@@ -51,7 +51,8 @@ class DefaultDetailsRepositoryTest {
     @Before
     fun setUp() {
         Dispatchers.setMain(testDispatcher)
-        repository = DefaultDetailsRepository(mockedApi,
+        repository = DefaultDetailsRepository(
+            mockedApi,
             mockedDao, mockedConnectivityHelper,
             testDispatcher
         )
@@ -106,40 +107,42 @@ class DefaultDetailsRepositoryTest {
         }
 
     @Test
-    fun `getData() returns two Loadings for server error and no internet`() = runTest(testDispatcher) {
+    fun `getData() returns two Loadings for server error and no internet`() =
+        runTest(testDispatcher) {
 
-        val urlPreviewData = UrlPreviewData(
-            MAIN_URL, SUCCESS_RESPONSE_TITLE,
-            SUCCESS_RESPONSE_DESCRIPTION, SUCCESS_RESPONSE_IMAGE_URL
-        )
+            val urlPreviewData = UrlPreviewData(
+                MAIN_URL, SUCCESS_RESPONSE_TITLE,
+                SUCCESS_RESPONSE_DESCRIPTION, SUCCESS_RESPONSE_IMAGE_URL
+            )
 
-        val responseBody = RESPONSE_ON_ERROR_CODE.toResponseBody("text/plain".toMediaTypeOrNull())
-        val response = Response.error<ResponseBody>(ERROR_RESPONSE_CODE, responseBody)
+            val responseBody =
+                RESPONSE_ON_ERROR_CODE.toResponseBody("text/plain".toMediaTypeOrNull())
+            val response = Response.error<ResponseBody>(ERROR_RESPONSE_CODE, responseBody)
 
-        `when`(mockedConnectivityHelper.isConnectedToInternet()).thenReturn(true)
-        `when`(mockedApi.getUrlPreview(MAIN_URL)).thenReturn(response)
-        `when`(mockedDao.getUrlInfo(MAIN_URL)).thenReturn(urlPreviewData)
+            `when`(mockedConnectivityHelper.isConnectedToInternet()).thenReturn(true)
+            `when`(mockedApi.getUrlPreview(MAIN_URL)).thenReturn(response)
+            `when`(mockedDao.getUrlInfo(MAIN_URL)).thenReturn(urlPreviewData)
 
-        `when`(mockedDao.deleteUrlInfo(urlPreviewData)).thenAnswer { }
-        `when`(mockedDao.upsertUrlInfo(urlPreviewData)).thenAnswer { }
+            `when`(mockedDao.deleteUrlInfo(urlPreviewData)).thenAnswer { }
+            `when`(mockedDao.upsertUrlInfo(urlPreviewData)).thenAnswer { }
 
-        repository.getUrlInfo(MAIN_URL).test {
+            repository.getUrlInfo(MAIN_URL).test {
 
-            val emptyLoading = awaitItem()
-            assertThat(emptyLoading).isInstanceOf(Resource.Loading::class.java)
-            assertThat(emptyLoading.data).isNull()
-            assertThat(emptyLoading.message).isNull()
+                val emptyLoading = awaitItem()
+                assertThat(emptyLoading).isInstanceOf(Resource.Loading::class.java)
+                assertThat(emptyLoading.data).isNull()
+                assertThat(emptyLoading.message).isNull()
 
-            val loadingWithData = awaitItem()
-            assertThat(loadingWithData).isInstanceOf(Resource.Loading::class.java)
-            assertThat(loadingWithData.data?.title).isEqualTo(SUCCESS_RESPONSE_TITLE)
-            assertThat(loadingWithData.data?.description).isEqualTo(SUCCESS_RESPONSE_DESCRIPTION)
-            assertThat(loadingWithData.data?.imageUrl).isEqualTo(SUCCESS_RESPONSE_IMAGE_URL)
+                val loadingWithData = awaitItem()
+                assertThat(loadingWithData).isInstanceOf(Resource.Loading::class.java)
+                assertThat(loadingWithData.data?.title).isEqualTo(SUCCESS_RESPONSE_TITLE)
+                assertThat(loadingWithData.data?.description).isEqualTo(SUCCESS_RESPONSE_DESCRIPTION)
+                assertThat(loadingWithData.data?.imageUrl).isEqualTo(SUCCESS_RESPONSE_IMAGE_URL)
 
-            awaitComplete()
-            cancel()
+                awaitComplete()
+                cancel()
+            }
         }
-    }
 
     @Test
     fun `getData() catches api exceptions`() = runTest(testDispatcher) {


### PR DESCRIPTION
- Resolves #11 by adding new quick settings tile to directly open app.
- Users can create and save QR codes of the history items or scanned QR Code in case if they wants to save the actual QR/Barcode for future use.
- Restructured the code by moving the camera permission methods to a new `PermissionHelper` class. This improves code organization and enhances readability.
- Resolved a bug where the bottom sheet drag handler was not functioning correctly. This fix ensures smooth and proper operation of the drag handler.
- Addressed a bug that caused the history item's icons to appear excessively large on landscape orientation.