### PR TITLE
Fix History screen missing details after upgrade in release builds

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -16,8 +16,8 @@ android {
         applicationId "com.yatik.qrscanner"
         minSdk 23
         targetSdk 35
-        versionCode 37
-        versionName "2.7.0"
+        versionCode 38
+        versionName "2.7.1"
 
 //        testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
         testInstrumentationRunner = "com.yatik.qrscanner.HiltTestRunner"

--- a/app/src/main/java/com/yatik/qrscanner/models/UrlPreviewData.kt
+++ b/app/src/main/java/com/yatik/qrscanner/models/UrlPreviewData.kt
@@ -1,12 +1,3 @@
-package com.yatik.qrscanner.models
-
-import android.os.Parcelable
-import androidx.room.ColumnInfo
-import androidx.room.Entity
-import androidx.room.PrimaryKey
-import com.google.errorprone.annotations.Keep
-import kotlinx.parcelize.Parcelize
-
 /*
  * Copyright 2023 Yatik
  *
@@ -23,13 +14,30 @@ import kotlinx.parcelize.Parcelize
  * limitations under the License.
  */
 
+package com.yatik.qrscanner.models
+
+import android.os.Parcelable
+import androidx.annotation.Keep
+import androidx.room.ColumnInfo
+import androidx.room.Entity
+import androidx.room.PrimaryKey
+import com.google.gson.annotations.SerializedName
+import kotlinx.parcelize.Parcelize
+
 @Keep
 @Parcelize
 @Entity(tableName = "url_info_table")
 data class UrlPreviewData(
     @PrimaryKey(autoGenerate = false)
+    @SerializedName("main_url")
     @ColumnInfo(name = "main_url") val mainUrl: String,
+    
+    @SerializedName("title")
     @ColumnInfo(name = "title") val title: String?,
+    
+    @SerializedName("description")
     @ColumnInfo(name = "description") val description: String?,
+    
+    @SerializedName("image_url")
     @ColumnInfo(name = "image_url") val imageUrl: String?
 ) : Parcelable

--- a/app/src/main/java/com/yatik/qrscanner/models/UrlPreviewData.kt
+++ b/app/src/main/java/com/yatik/qrscanner/models/UrlPreviewData.kt
@@ -31,13 +31,12 @@ data class UrlPreviewData(
     @PrimaryKey(autoGenerate = false)
     @SerializedName("main_url")
     @ColumnInfo(name = "main_url") val mainUrl: String,
-    
+
     @SerializedName("title")
     @ColumnInfo(name = "title") val title: String?,
-    
+
     @SerializedName("description")
     @ColumnInfo(name = "description") val description: String?,
-    
     @SerializedName("image_url")
     @ColumnInfo(name = "image_url") val imageUrl: String?
 ) : Parcelable

--- a/app/src/main/java/com/yatik/qrscanner/models/barcode/BarcodeDetails.kt
+++ b/app/src/main/java/com/yatik/qrscanner/models/barcode/BarcodeDetails.kt
@@ -18,6 +18,7 @@ package com.yatik.qrscanner.models.barcode
 
 import android.os.Parcelable
 import androidx.annotation.Keep
+import com.google.gson.annotations.SerializedName
 import com.yatik.qrscanner.models.barcode.data.CalendarEvent
 import com.yatik.qrscanner.models.barcode.data.Contact
 import com.yatik.qrscanner.models.barcode.data.Email
@@ -39,71 +40,85 @@ data class BarcodeDetails (
     /**
      * The barcode or QR code format.
      * */
+    @SerializedName("format")
     val format: Format,
 
     /**
      * The type of QR Code, if applicable.
      */
+    @SerializedName("type")
     val type: Type,
 
     /**
      * The date and time of scanning in DD-MM-YYYY HH:MM:SS format.
      */
+    @SerializedName("timeStamp")
     val timeStamp: String?,
 
     /**
      * The raw and unmodified content of the barcode or QR Code.
      */
+    @SerializedName("rawValue")
     val rawValue: String,
 
     /**
      * The text content of QR Code.
      */
+    @SerializedName("text")
     val text: String? = null,
 
     /**
      * The [Sms] extracted from the barcode or QR code, if applicable.
      */
+    @SerializedName("sms")
     val sms: Sms? = null,
 
     /**
      * The [Url] extracted from the barcode or QR code, if applicable.
      */
+    @SerializedName("url")
     val url: Url? = null,
 
     /**
      * The [WiFi] information such as SSID, password,
      * and [com.yatik.qrscanner.models.barcode.data.Security] type extracted from QR code, if applicable.
      */
+    @SerializedName("wiFi")
     val wiFi: WiFi? = null,
 
     /**
      * The [Phone] contact extracted from the barcode or QR code, if applicable.
      */
+    @SerializedName("phone")
     val phone: Phone? = null,
 
     /**
      * The [Email] extracted from the QR code, if applicable.
      */
+    @SerializedName("email")
     val email: Email? = null,
 
     /**
      * The [Geo] coordinates extracted from the QR code, if applicable.
      */
+    @SerializedName("geo")
     val geo: Geo? = null,
 
     /**
      * The [Contact] extracted from the QR code, if applicable.
      */
+    @SerializedName("contact")
     val contact: Contact? = null,
 
     /**
      * The [CalendarEvent] extracted from the QR code, if applicable.
      */
+    @SerializedName("calendarEvent")
     val calendarEvent: CalendarEvent? = null,
 
     /**
      * The ISBN number extracted from the QR code, if applicable.
      */
+    @SerializedName("isbn")
     val isbn: String? = null
 ) : Parcelable

--- a/app/src/main/java/com/yatik/qrscanner/models/barcode/data/CalendarEvent.kt
+++ b/app/src/main/java/com/yatik/qrscanner/models/barcode/data/CalendarEvent.kt
@@ -17,14 +17,19 @@
 package com.yatik.qrscanner.models.barcode.data
 
 import android.os.Parcelable
-import com.google.errorprone.annotations.Keep
+import androidx.annotation.Keep
+import com.google.gson.annotations.SerializedName
 import kotlinx.parcelize.Parcelize
 
 @Keep
 @Parcelize
 data class CalendarEvent(
+    @SerializedName("description")
     val description: String?,
+    @SerializedName("start")
     val start: String?,
+    @SerializedName("end")
     val end: String?,
+    @SerializedName("organizer")
     val organizer: String?
 ) : Parcelable

--- a/app/src/main/java/com/yatik/qrscanner/models/barcode/data/Contact.kt
+++ b/app/src/main/java/com/yatik/qrscanner/models/barcode/data/Contact.kt
@@ -17,15 +17,21 @@
 package com.yatik.qrscanner.models.barcode.data
 
 import android.os.Parcelable
-import com.google.errorprone.annotations.Keep
+import androidx.annotation.Keep
+import com.google.gson.annotations.SerializedName
 import kotlinx.parcelize.Parcelize
 
 @Keep
 @Parcelize
 data class Contact(
+    @SerializedName("name")
     val name: String?,
+    @SerializedName("phone")
     val phone: String?,
+    @SerializedName("phoneType")
     val phoneType: ContactType?,
+    @SerializedName("email")
     val email: String?,
+    @SerializedName("emailType")
     val emailType: ContactType?
 ) : Parcelable

--- a/app/src/main/java/com/yatik/qrscanner/models/barcode/data/Email.kt
+++ b/app/src/main/java/com/yatik/qrscanner/models/barcode/data/Email.kt
@@ -17,14 +17,19 @@
 package com.yatik.qrscanner.models.barcode.data
 
 import android.os.Parcelable
-import com.google.errorprone.annotations.Keep
+import androidx.annotation.Keep
+import com.google.gson.annotations.SerializedName
 import kotlinx.parcelize.Parcelize
 
 @Keep
 @Parcelize
 data class Email(
+    @SerializedName("email")
     val email: String?,
+    @SerializedName("subject")
     val subject: String?,
+    @SerializedName("message")
     val message: String?,
+    @SerializedName("type")
     val type: ContactType?
 ) : Parcelable

--- a/app/src/main/java/com/yatik/qrscanner/models/barcode/data/Geo.kt
+++ b/app/src/main/java/com/yatik/qrscanner/models/barcode/data/Geo.kt
@@ -17,12 +17,15 @@
 package com.yatik.qrscanner.models.barcode.data
 
 import android.os.Parcelable
-import com.google.errorprone.annotations.Keep
+import androidx.annotation.Keep
+import com.google.gson.annotations.SerializedName
 import kotlinx.parcelize.Parcelize
 
 @Keep
 @Parcelize
 data class Geo(
+    @SerializedName("latitude")
     val latitude: Double?,
+    @SerializedName("longitude")
     val longitude: Double?
 ) : Parcelable

--- a/app/src/main/java/com/yatik/qrscanner/models/barcode/data/Phone.kt
+++ b/app/src/main/java/com/yatik/qrscanner/models/barcode/data/Phone.kt
@@ -17,7 +17,7 @@
 package com.yatik.qrscanner.models.barcode.data
 
 import android.os.Parcelable
-import com.google.errorprone.annotations.Keep
+import androidx.annotation.Keep
 import com.google.gson.annotations.SerializedName
 import kotlinx.parcelize.Parcelize
 
@@ -32,7 +32,10 @@ enum class ContactType {
 @Keep
 @Parcelize
 data class Phone(
+    @SerializedName("name")
     val name: String?,
+    @SerializedName("number")
     val number: String?,
+    @SerializedName("type")
     val type: ContactType?
 ) : Parcelable

--- a/app/src/main/java/com/yatik/qrscanner/models/barcode/data/Sms.kt
+++ b/app/src/main/java/com/yatik/qrscanner/models/barcode/data/Sms.kt
@@ -17,12 +17,15 @@
 package com.yatik.qrscanner.models.barcode.data
 
 import android.os.Parcelable
-import com.google.errorprone.annotations.Keep
+import androidx.annotation.Keep
+import com.google.gson.annotations.SerializedName
 import kotlinx.parcelize.Parcelize
 
 @Keep
 @Parcelize
 data class Sms(
+    @SerializedName("number")
     val number: String?,
+    @SerializedName("message")
     val message: String?
 ) : Parcelable

--- a/app/src/main/java/com/yatik/qrscanner/models/barcode/data/Url.kt
+++ b/app/src/main/java/com/yatik/qrscanner/models/barcode/data/Url.kt
@@ -17,12 +17,15 @@
 package com.yatik.qrscanner.models.barcode.data
 
 import android.os.Parcelable
-import com.google.errorprone.annotations.Keep
+import androidx.annotation.Keep
+import com.google.gson.annotations.SerializedName
 import kotlinx.parcelize.Parcelize
 
 @Keep
 @Parcelize
 data class Url(
+    @SerializedName("title")
     val title: String?,
+    @SerializedName("url")
     val url: String?
 ) : Parcelable

--- a/app/src/main/java/com/yatik/qrscanner/models/barcode/data/WiFi.kt
+++ b/app/src/main/java/com/yatik/qrscanner/models/barcode/data/WiFi.kt
@@ -17,7 +17,7 @@
 package com.yatik.qrscanner.models.barcode.data
 
 import android.os.Parcelable
-import com.google.errorprone.annotations.Keep
+import androidx.annotation.Keep
 import com.google.gson.annotations.SerializedName
 import kotlinx.parcelize.Parcelize
 
@@ -32,7 +32,10 @@ enum class Security {
 @Keep
 @Parcelize
 data class WiFi(
+    @SerializedName("ssid")
     val ssid: String?,
+    @SerializedName("password")
     val password: String?,
+    @SerializedName("security")
     val security: Security?
 ) : Parcelable


### PR DESCRIPTION
This PR resolves an issue where the **History screen failed to display QR code details** for previously scanned items after upgrading the app in **release builds**.

The issue did not affect debug builds and only surfaced after upgrading versions, leading to missing or null data in the UI for historical entries.

---

## **Root Cause**

The problem stemmed from a combination of **R8/ProGuard obfuscation** and **GSON deserialization behavior**:

* **Field Obfuscation**
  In release builds, R8 renames class fields (e.g., `text` → `a`), altering the expected JSON mapping.

* **Missing / Incorrect Annotations**

  * Several model classes lacked `@SerializedName`, forcing GSON to rely on actual field names.
  * Some classes incorrectly used `com.google.errorprone.annotations.Keep`, which does **not** prevent R8 obfuscation.

* **Deserialization Failure After Upgrade**
  After upgrading the app, obfuscated field names changed.
  As a result, GSON could no longer map stored JSON (in Room DB) to the new model structure, leading to null values in the UI.

---

## **Changes**

* **Standardized `@Keep` Usage**
  Replaced all incorrect `@Keep` imports with `androidx.annotation.Keep` to ensure R8 preserves model classes and fields.

* **Added `@SerializedName` Annotations**
  Added explicit `@SerializedName` annotations to all fields in:

  * `BarcodeDetails`
  * Associated data models: `Url`, `Sms`, `WiFi`, `Geo`, `Phone`, `Email`, `Contact`, `CalendarEvent`
  * `UrlPreviewData`

  This ensures stable JSON mapping regardless of obfuscation.

* **Version Update**

  * `versionCode`: 38
  * `versionName`: 2.7.1

---

## **Files Modified**

* `app/src/main/java/com/yatik/qrscanner/models/barcode/BarcodeDetails.kt`
* `app/src/main/java/com/yatik/qrscanner/models/barcode/data/*.kt`
* `app/src/main/java/com/yatik/qrscanner/models/UrlPreviewData.kt`
* `app/build.gradle`
